### PR TITLE
Include debug information when doing on-the-fly compilation.

### DIFF
--- a/Utilities/ReflectionUtilities.cs
+++ b/Utilities/ReflectionUtilities.cs
@@ -325,6 +325,7 @@ namespace APSIM.Shared.Utilities
                             Params.OutputAssembly = assemblyFileName;
                         }
                         Params.TreatWarningsAsErrors = false;
+                        Params.IncludeDebugInformation = true;
                         Params.WarningLevel = 2;
                         Params.ReferencedAssemblies.Add("System.dll");
                         Params.ReferencedAssemblies.Add("System.Xml.dll");


### PR DESCRIPTION
Include debug information so that error messages can display a line number, as requested by Neil Huth in APSIMInitiative/ApsimX #139. Resolves that issue.