### PR TITLE
Get rid of code bits triggering warnings when compiled with the Mono …

### DIFF
--- a/Soils/Defaults.cs
+++ b/Soils/Defaults.cs
@@ -8,7 +8,6 @@ namespace APSIM.Shared.Soils
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using APSIM.Shared.Utilities;
 
     /// <summary>Implements the defaults as listed in the soil protocol.</summary>
@@ -242,23 +241,23 @@ namespace APSIM.Shared.Soils
         /// <summary>
         /// The canola kl
         /// </summary>
-        private static double[] CanolaKL = new double[] { 0.06, 0.06, 0.06, 0.04, 0.04, 0.02, 0.01 };
+        /// private static double[] CanolaKL = new double[] { 0.06, 0.06, 0.06, 0.04, 0.04, 0.02, 0.01 };
         /// <summary>
         /// The pigeon pea kl
         /// </summary>
-        private static double[] PigeonPeaKL = new double[] { 0.06, 0.06, 0.06, 0.05, 0.04, 0.02, 0.01 };
+        /// private static double[] PigeonPeaKL = new double[] { 0.06, 0.06, 0.06, 0.05, 0.04, 0.02, 0.01 };
         /// <summary>
         /// The maize kl
         /// </summary>
-        private static double[] MaizeKL = new double[] { 0.06, 0.06, 0.06, 0.04, 0.04, 0.02, 0.01 };
+        /// private static double[] MaizeKL = new double[] { 0.06, 0.06, 0.06, 0.04, 0.04, 0.02, 0.01 };
         /// <summary>
         /// The cowpea kl
         /// </summary>
-        private static double[] CowpeaKL = new double[] { 0.06, 0.06, 0.06, 0.04, 0.04, 0.02, 0.01 };
+        /// private static double[] CowpeaKL = new double[] { 0.06, 0.06, 0.06, 0.04, 0.04, 0.02, 0.01 };
         /// <summary>
         /// The sunflower kl
         /// </summary>
-        private static double[] SunflowerKL = new double[] { 0.01, 0.01, 0.08, 0.06, 0.04, 0.02, 0.01 };
+        /// private static double[] SunflowerKL = new double[] { 0.01, 0.01, 0.08, 0.06, 0.04, 0.02, 0.01 };
         /// <summary>
         /// The fababean kl
         /// </summary>
@@ -266,11 +265,11 @@ namespace APSIM.Shared.Soils
         /// <summary>
         /// The lucerne kl
         /// </summary>
-        private static double[] LucerneKL = new double[] { 0.01, 0.01, 0.01, 0.01, 0.09, 0.09, 0.09 };
+        /// private static double[] LucerneKL = new double[] { 0.01, 0.01, 0.01, 0.01, 0.09, 0.09, 0.09 };
         /// <summary>
         /// The perennial kl
         /// </summary>
-        private static double[] PerennialKL = new double[] { 0.01, 0.01, 0.01, 0.01, 0.09, 0.07, 0.05 };
+        /// private static double[] PerennialKL = new double[] { 0.01, 0.01, 0.01, 0.01, 0.09, 0.07, 0.05 };
 
         /// <summary>
         /// 
@@ -508,7 +507,6 @@ namespace APSIM.Shared.Soils
         /// <returns></returns>
         private static double[] PredictedLL(Soil soil, double[] A, double B)
         {
-            double[] DepthCentre = SoilUtilities.ToMidPoints(PredictedThickness);
             double[] LL15 = LayerStructure.LL15Mapped(soil, PredictedThickness);
             double[] DUL = LayerStructure.DULMapped(soil, PredictedThickness);
             double[] LL = new double[PredictedThickness.Length];

--- a/Soils/LayerStructure.cs
+++ b/Soils/LayerStructure.cs
@@ -176,8 +176,6 @@ namespace APSIM.Shared.Soils
         {
             if (!MathUtilities.AreEqual(thickness, sample.Thickness))
             {
-                string[] metadata = StringUtilities.CreateStringArray("Mapped", thickness.Length);
-
                 sample.Name = sample.Name;
                 sample.Date = sample.Date;
 

--- a/Utilities/MathUtilities.cs
+++ b/Utilities/MathUtilities.cs
@@ -761,8 +761,8 @@ namespace APSIM.Shared.Utilities
             double SumY2 = 0;
             double CSSX, CSSXY;
             double Xbar, Ybar;
-            double TSS, TSSM;
-            double REGSS, REGSSM;
+            double TSS;
+            double REGSS;
             double RESIDSS, RESIDSSM;
             double S2;
             double SumOfSquaredResiduals = 0;   //SUM i=1->n  ((P(i) - O(i)) ^ 2)
@@ -830,9 +830,7 @@ namespace APSIM.Shared.Utilities
             stats.Intercept = Ybar - stats.Slope * Xbar;  // Calculate intercept
 
             TSS = SumY2 - SumY * SumY / Num_points;       // Corrected SS for Y = Sum((y-ybar)^2)
-            TSSM = TSS / (Num_points - 1);                // Total mean SS
             REGSS = stats.Slope * CSSXY;                  // SS due to regression = Sum((yest-ybar)^2)
-            REGSSM = REGSS;                               // Regression mean SS
             RESIDSS = TSS - REGSS;                        // SS about the regression = Sum((y-yest)^2)
 
             if (Num_points > 2)                           // MUST HAVE MORE THAN TWO POINTS FOR REG

--- a/Utilities/MetUtilities.cs
+++ b/Utilities/MetUtilities.cs
@@ -494,7 +494,6 @@ namespace APSIM.Shared.Utilities
             // ------------------------------------------------------------------------
             double dHS = 0;
             double start = 0;
-            double finish = 0;
             double T = 0;
             double M1 = 0;
             double M2 = 0;
@@ -502,10 +501,8 @@ namespace APSIM.Shared.Utilities
 
             dHS = System.Math.Abs(HS2 - HS1);
             start = System.Math.Min(HS1, HS2);
-            finish = System.Math.Max(HS1, HS2);
 
             functionReturnValue = 0.0;
-
 
             for (i = 1; i <= Convert.ToInt32(itns); i++)
             {
@@ -516,7 +513,6 @@ namespace APSIM.Shared.Utilities
             }
             return functionReturnValue;
             //Beep
-
         }
 
         // ------------------------------------------------------------------------

--- a/Utilities/StringUtilities.cs
+++ b/Utilities/StringUtilities.cs
@@ -818,7 +818,7 @@ namespace APSIM.Shared.Utilities
 
             if (token.Length > 0 && token.IndexOf('E') == token.Length - 1)  // Number is in exponential format
             {
-                bool dummy = MatchToken(ref parseSt, "+");       
+                MatchToken(ref parseSt, "+");       
                 int exponent = 0;
                 if (TokenInt(ref parseSt, ref exponent))
                     token = token + exponent.ToString();  // Add the exponent to token
@@ -861,7 +861,7 @@ namespace APSIM.Shared.Utilities
 
             if (token.Length > 0 && token.IndexOf('E') == token.Length - 1)  // Number is in exponential format
             {
-                bool dummy = MatchToken(ref parseSt, "+");
+                MatchToken(ref parseSt, "+");
                 int exponent = 0;
                 if (TokenInt(ref parseSt, ref exponent))
                     token = token + exponent.ToString();  // Add the exponent to token


### PR DESCRIPTION
…compiler. These were mostly variables which were being assigned values, but were never used.

This is intended to allow compilation with the Mono compiler without having to tinker with compiler settings. See ApsimX#860