### PR TITLE
If a field can be parsed as a date in the current culture, try to wor…

### DIFF
--- a/Utilities/StringUtilities.cs
+++ b/Utilities/StringUtilities.cs
@@ -367,7 +367,7 @@ namespace APSIM.Shared.Utilities
             else if (MathUtilities.IsNumericalenUS(value))
                 ColumnType = Type.GetType("System.Single");
 
-            else if (units == "" && StringUtilities.IsDateTime(value))
+            else if ((units == "" || units == "()") && StringUtilities.IsDateTime(value))
                 ColumnType = Type.GetType("System.DateTime");
 
             else if ((units.Contains("d") && units.Contains("/") && units.Contains("y"))


### PR DESCRIPTION
…k out the exact DateTime format.
Resolves an issue raised by Val Snow on Slack, in which a field in an input file was recognised as a DateTime field, but could not be correctly parsed later.