### PR TITLE
Added System.Core.dll to the list of assemblies when compiling a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ obj/Debug/APSIM.Shared.csproj.FileListAbsolute.txt
 *.cache
 obj/
 *.user
+.vs/APSIM.Shared/v15/Server/sqlite3/storage.ide
+.vs/APSIM.Shared/v15/Server/sqlite3/db.lock

--- a/Utilities/ReflectionUtilities.cs
+++ b/Utilities/ReflectionUtilities.cs
@@ -343,6 +343,7 @@ namespace APSIM.Shared.Utilities
                         Params.ReferencedAssemblies.Add("System.Xml.dll");
                         Params.ReferencedAssemblies.Add("System.Windows.Forms.dll");
                         Params.ReferencedAssemblies.Add("System.Data.dll");
+                        Params.ReferencedAssemblies.Add("System.Core.dll");
                         //Params.ReferencedAssemblies.Add("APSIM.Shared.dll");
                         Params.ReferencedAssemblies.Add(System.IO.Path.Combine(Assembly.GetExecutingAssembly().Location));
 


### PR DESCRIPTION
When creating model documentation, the list of tabs, which is now stored as a list of IPresenter objects, need to be filtered to a list of ExplorerPresenter. This was done with the IEnumerable.OfType method, which is in the namespace System.Linq, which is located in System.Core.dll. This assembly is now included by default when compiling a file. 

A better solution in the long-term might be to check which namespaces are referenced by the file, and then dynamically add the appropriate assemblies.