### PR TITLE
Provide correct DLL name for Linq services.

### DIFF
--- a/Utilities/ReflectionUtilities.cs
+++ b/Utilities/ReflectionUtilities.cs
@@ -343,7 +343,7 @@ namespace APSIM.Shared.Utilities
                         Params.ReferencedAssemblies.Add("System.Xml.dll");
                         Params.ReferencedAssemblies.Add("System.Windows.Forms.dll");
                         Params.ReferencedAssemblies.Add("System.Data.dll");
-                        Params.ReferencedAssemblies.Add("System.Linq.dll");
+                        Params.ReferencedAssemblies.Add("System.Core.dll");
                         //Params.ReferencedAssemblies.Add("APSIM.Shared.dll");
                         Params.ReferencedAssemblies.Add(System.IO.Path.Combine(Assembly.GetExecutingAssembly().Location));
 


### PR DESCRIPTION
Using the wrong name broke builds running on Mono.