### PR TITLE
Open SQLite DB in serialised (unrestricted) mode.

### DIFF
--- a/Utilities/SQLite.cs
+++ b/Utilities/SQLite.cs
@@ -300,9 +300,9 @@ namespace APSIM.Shared.Utilities
         {
             int id;
             if (readOnly)
-                id = sqlite3_open_v2(path, out _db, SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX, null);
+                id = sqlite3_open_v2(path, out _db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, null);
             else
-                id = sqlite3_open_v2(path, out _db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_CREATE, null);
+                id = sqlite3_open_v2(path, out _db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_CREATE, null);
 
             if (id != SQLITE_OK)
             {


### PR DESCRIPTION
Resolves APSIMInitiative/ApsimX#3139

This seems to solve some of the threading problems we've been encountering, I think. It's ~hard~ virtually impossible to tell with these things, but I've run the wheat validation set and chickpea prototype (using both job runners) and haven't seen any problems.

@zur003 Did you compile the SQLite binary which we are using? If so, do you remember which compile-time flags you set? I ask because, according to the docs:

> If the SQLITE_OPEN_FULLMUTEX flag is set then the database connection opens in the serialized threading mode unless single-thread was previously selected at compile-time or start-time.