### PR TITLE
Added a method to get a Windows short filename from a long filename.

### DIFF
--- a/Utilities/PathUtilities.cs
+++ b/Utilities/PathUtilities.cs
@@ -8,12 +8,46 @@ namespace APSIM.Shared.Utilities
     using System;
     using System.IO;
     using System.Reflection;
+    using System.Runtime.InteropServices;
+    using System.Text;
 
     /// <summary>
     /// A collection of path utilities.
     /// </summary>
     public class PathUtilities
     {
+        private const int maxPathLength = 255;
+
+        /// <summary>
+        /// Gets a short path name.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="shortPath"></param>
+        /// <param name="shortPathLength"></param>
+        /// <returns></returns>
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern int GetShortPathName(
+            [MarshalAs(UnmanagedType.LPTStr)]
+                 string path,
+            [MarshalAs(UnmanagedType.LPTStr)]
+                 StringBuilder shortPath,
+            int shortPathLength
+        );
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string GetShortPath(string path)
+        {
+            if (!File.Exists(path))
+                File.Create(path).Close();
+            var shortPath = new StringBuilder(maxPathLength);
+            GetShortPathName(path, shortPath, maxPathLength);
+            return shortPath.ToString();
+        }
+
         /// <summary>
         /// Convert the specified URL to a path.
         /// </summary>

--- a/Utilities/PathUtilities.cs
+++ b/Utilities/PathUtilities.cs
@@ -16,15 +16,17 @@ namespace APSIM.Shared.Utilities
     /// </summary>
     public class PathUtilities
     {
+        /// <summary>
+        /// Maximum allowed length of a file name on Windows.
+        /// </summary>
         private const int maxPathLength = 255;
 
         /// <summary>
-        /// Gets a short path name.
+        /// Gets a Windows short file name.
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="shortPath"></param>
-        /// <param name="shortPathLength"></param>
-        /// <returns></returns>
+        /// <param name="path">Path to the file.</param>
+        /// <param name="shortPath">Output value.</param>
+        /// <param name="shortPathLength">Maximum allowed length of a path.</param>
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
         private static extern int GetShortPathName(
             [MarshalAs(UnmanagedType.LPTStr)]
@@ -35,10 +37,9 @@ namespace APSIM.Shared.Utilities
         );
 
         /// <summary>
-        /// 
+        /// Gets a Windows short file name.
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
+        /// <param name="path">Path to the file.</param>
         public static string GetShortPath(string path)
         {
             if (!File.Exists(path))


### PR DESCRIPTION
Working on APSIMInitiative/ApsimX#3219

Edit: I should mention that this is only called on Windows, and doesn't seem to cause any problems on Ubuntu. Haven't tested on MacOS.