### PR TITLE
Reduced tolerance for divde by zero condition in expression parser.

### DIFF
--- a/Utilities/ExpressionEvaluator.cs
+++ b/Utilities/ExpressionEvaluator.cs
@@ -585,7 +585,7 @@ namespace APSIM.Shared.Utilities
                         }
                         else
                         {
-                            if (!MathUtilities.FloatsAreEqual(sym2.m_value, 0))
+                            if (!MathUtilities.FloatsAreEqual(sym2.m_value, 0, 1E-12))
                                 result.m_value = sym1.m_value / sym2.m_value;
                             else
                             {


### PR DESCRIPTION
This is needed to get APSIMInitiative/ApsimX#3302 the red clover prototype to run without error...some expressions in the report get very close to division by zero.