### PR TITLE
Add generic function to sum array between 2 indices

### DIFF
--- a/Utilities/MathUtilities.cs
+++ b/Utilities/MathUtilities.cs
@@ -332,6 +332,30 @@ namespace APSIM.Shared.Utilities
 
             return result;
         }
+
+        /// <summary>
+        /// Sum an array of numbers starting at startIndex up to endIndex (inclusive)
+        /// </summary>
+        public static double Sum(IEnumerable Values, int iStartIndex, int iEndIndex)
+        {
+            double result = 0.0;
+            if (iStartIndex > iEndIndex)
+                throw new Exception("MathUtilities.Sum: Start index is greater than end index");
+            if (iStartIndex < 0 || iEndIndex >= (Values as Array).Length)
+                throw new Exception("MathUtilities.Sum: End index or start index is out of range");
+            int iIndex = -1;
+            foreach (double Value in Values)
+            {
+                iIndex++;
+                if (iIndex >= iStartIndex && Value != MissingValue)
+                    result += Value;
+                if (iIndex == iEndIndex)
+                    break; ;
+            }
+
+            return result;
+        }
+
         /// <summary>
         ///Linearly interpolates a value y for a given value x and a given
         ///set of xy co-ordinates.

--- a/Utilities/MathUtilities.cs
+++ b/Utilities/MathUtilities.cs
@@ -336,21 +336,21 @@ namespace APSIM.Shared.Utilities
         /// <summary>
         /// Sum an array of numbers starting at startIndex up to endIndex (inclusive)
         /// </summary>
-        public static double Sum(IEnumerable Values, int iStartIndex, int iEndIndex)
+        public static double Sum(IEnumerable values, int startIndex, int endIndex)
         {
             double result = 0.0;
-            if (iStartIndex > iEndIndex)
+            if (startIndex > endIndex)
                 throw new Exception("MathUtilities.Sum: Start index is greater than end index");
-            if (iStartIndex < 0 || iEndIndex >= (Values as Array).Length)
+            if (startIndex < 0 || endIndex >= (values as Array).Length)
                 throw new Exception("MathUtilities.Sum: End index or start index is out of range");
-            int iIndex = -1;
-            foreach (double Value in Values)
+            int index = -1;
+            foreach (double value in values)
             {
-                iIndex++;
-                if (iIndex >= iStartIndex && Value != MissingValue)
-                    result += Value;
-                if (iIndex == iEndIndex)
-                    break; ;
+                index++;
+                if (index >= startIndex && value != MissingValue)
+                    result += value;
+                if (index == endIndex)
+                    break;
             }
 
             return result;


### PR DESCRIPTION
Adding a more generic function to add items in an array given a start and an end index. These are inclusive, which is more intuitive and thus can be used to sum any array, not only soil.
This is a small modification of the one function already in the code, which seem to be legacy code and thus I don't want to mess with.
This should resolves #3372
