### PR TITLE
Add MathNet.Numerics.dll to manager script's references.

### DIFF
--- a/Utilities/ReflectionUtilities.cs
+++ b/Utilities/ReflectionUtilities.cs
@@ -346,6 +346,7 @@ namespace APSIM.Shared.Utilities
                         Params.ReferencedAssemblies.Add("System.Windows.Forms.dll");
                         Params.ReferencedAssemblies.Add("System.Data.dll");
                         Params.ReferencedAssemblies.Add("System.Core.dll");
+                        Params.ReferencedAssemblies.Add("MathNet.Numerics.dll");
                         //Params.ReferencedAssemblies.Add("APSIM.Shared.dll");
                         Params.ReferencedAssemblies.Add(System.IO.Path.Combine(Assembly.GetExecutingAssembly().Location));
 


### PR DESCRIPTION
Working on APSIMInitiative/ApsimX#3673

@hol353 is this code used in any other projects? This might cause breakages if MathNet.Numerics can't be found.